### PR TITLE
Creation of the  shipment model with tests and validations

### DIFF
--- a/shipments_tracker/Gemfile
+++ b/shipments_tracker/Gemfile
@@ -66,6 +66,7 @@ end
 
 group :test do
   gem 'minitest'
+  gem 'pry'
 end
 
 group :test do

--- a/shipments_tracker/Gemfile.lock
+++ b/shipments_tracker/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -128,6 +129,9 @@ GEM
     nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
     pg (1.5.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.3)
     puma (5.6.6)
       nio4r (~> 2.0)
@@ -218,6 +222,7 @@ DEPENDENCIES
   jbuilder
   minitest
   pg (~> 1.1)
+  pry
   puma (~> 5.0)
   rails (~> 7.0.6)
   selenium-webdriver

--- a/shipments_tracker/app/models/shipment.rb
+++ b/shipments_tracker/app/models/shipment.rb
@@ -1,0 +1,13 @@
+class Shipment < ApplicationRecord
+  # Validación: El campo account_id no puede estar vacío
+  validates :account_id, presence: true
+
+  # Validación: El campo status no puede estar vacío y solo puede contener los valore especificados
+  validates :status, presence: true, inclusion: { in: %w(registered  in_transit delayed lost stolen delivered) }
+
+  # Validación: El campo tracking_history no puede estar vacío y debe tener al menos un elemento (longitud mínima de 1)
+  validates :tracking_history, presence: true, length: { minimum: 1 }
+
+  # Validación: El campo tracking_number no puede estar vacío y debe ser único en la tabla
+  validates :tracking_number, presence: true, uniqueness: true
+end

--- a/shipments_tracker/db/migrate/20230802162213_create_shipments.rb
+++ b/shipments_tracker/db/migrate/20230802162213_create_shipments.rb
@@ -1,0 +1,15 @@
+class CreateShipments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shipments do |t|
+      t.references :account
+      t.string :status
+      t.string :tracking_history, array: true, default: []
+      t.string :tracking_number
+
+      t.timestamps null: false
+    end
+
+    add_index :shipments, :id, unique: true
+    add_index :shipments, :tracking_number
+  end
+end

--- a/shipments_tracker/db/schema.rb
+++ b/shipments_tracker/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_01_222313) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_02_162213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_01_222313) do
     t.boolean "active"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "shipments", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "status"
+    t.string "tracking_history", default: [], array: true
+    t.string "tracking_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_shipments_on_account_id"
+    t.index ["id"], name: "index_shipments_on_id", unique: true
+    t.index ["tracking_number"], name: "index_shipments_on_tracking_number"
   end
 
 end

--- a/shipments_tracker/test/models/shipment_test.rb
+++ b/shipments_tracker/test/models/shipment_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class ShipmentTest < ActiveSupport::TestCase
+  def setup
+    @account = Account.create(company_name: 'test', active: true)
+    @shipment = Shipment.new(
+      account_id: @account.id,
+      status: "registered",
+      tracking_history: ["Event 1"],
+      tracking_number: "ABC123"
+    )
+  end
+
+  test "should be valid" do
+    assert @shipment.valid?, @shipment.errors.full_messages.join(", ")
+  end
+
+  test "should require account_id" do
+    @shipment.account_id = nil
+    assert_not @shipment.valid?, @shipment.errors.full_messages.join(", ")
+  end
+
+  test "should require status" do
+    @shipment.status = nil
+    assert_not @shipment.valid?, @shipment.errors.full_messages.join(", ")
+  end
+end


### PR DESCRIPTION
# Description

What did you implement/Why did you implement this?
- The creation of the shipping model was implemented in the database with its validations at the model level and its own tests
- Added pry gem for easy debugging

## Evidence
- You can run rails test in console once inside the
  shippings_tracker project

## Screenshots
Tests on console
<img width="1440" alt="Screenshot 2023-08-02 at 16 59 29" src="https://github.com/BrightCoders-Institute/proyecto-final-ror-team1/assets/42948949/9ed0e077-08be-4788-9209-6e2b61b5bcc8">
tests with Minitest
<img width="1440" alt="Screenshot 2023-08-02 at 17 01 47" src="https://github.com/BrightCoders-Institute/proyecto-final-ror-team1/assets/42948949/b82e83ce-0895-4fff-826f-ec9fe7106a2b">
