### PR TITLE
Feature/add shipments index endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 # Ignore master key for decrypting credentials and more.
 /shipments_tracker/config/master.key
 tmp/rubycritic/.DS_Store
+.DS_Store

--- a/shipments_tracker/Gemfile
+++ b/shipments_tracker/Gemfile
@@ -56,6 +56,8 @@ gem 'rails_admin', '~> 3.0'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'minitest'
+  gem 'pry'
 end
 
 group :development do
@@ -67,11 +69,6 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-end
-
-group :test do
-  gem 'minitest'
-  gem 'pry'
 end
 
 group :test do

--- a/shipments_tracker/app/controllers/application_controller.rb
+++ b/shipments_tracker/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  
   def current_account
     current_user.account
   end

--- a/shipments_tracker/app/controllers/application_controller.rb
+++ b/shipments_tracker/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
-  
   def current_account
     current_user.account
   end

--- a/shipments_tracker/app/controllers/application_controller.rb
+++ b/shipments_tracker/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
-
+  
   def current_account
     current_user.account
   end

--- a/shipments_tracker/app/controllers/shipments_controller.rb
+++ b/shipments_tracker/app/controllers/shipments_controller.rb
@@ -1,16 +1,12 @@
 class ShipmentsController < ApplicationController
-
-
   def show
     @shipment = find_shipment
   end
 
-  private
-
   def find_shipment
     Shipment.find(params[:id])
   end
-
+  
   def index
      @shipments = Shipment.where(account_id: current_account.id)
 

--- a/shipments_tracker/app/controllers/shipments_controller.rb
+++ b/shipments_tracker/app/controllers/shipments_controller.rb
@@ -25,4 +25,3 @@ class ShipmentsController < ApplicationController
   def permitted_params
     params.permit(:carrier_name, :status)
   end
-end

--- a/shipments_tracker/app/controllers/shipments_controller.rb
+++ b/shipments_tracker/app/controllers/shipments_controller.rb
@@ -25,3 +25,4 @@ class ShipmentsController < ApplicationController
   def permitted_params
     params.permit(:carrier_name, :status)
   end
+end

--- a/shipments_tracker/app/helpers/shipments_helper.rb
+++ b/shipments_tracker/app/helpers/shipments_helper.rb
@@ -11,3 +11,7 @@ module ShipmentsHelper
     Shipment::STATUSES
   end
 end
+
+# @shipments.each do |shipment|
+#   tracking_status(shipment.status)
+# end

--- a/shipments_tracker/app/helpers/shipments_helper.rb
+++ b/shipments_tracker/app/helpers/shipments_helper.rb
@@ -11,7 +11,3 @@ module ShipmentsHelper
     Shipment::STATUSES
   end
 end
-
-# @shipments.each do |shipment|
-#   tracking_status(shipment.status)
-# end

--- a/shipments_tracker/app/views/layouts/application.html.erb
+++ b/shipments_tracker/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+
     <%= javascript_importmap_tags %>
   </head>
 

--- a/shipments_tracker/test/controllers/shipments_controller_test.rb
+++ b/shipments_tracker/test/controllers/shipments_controller_test.rb
@@ -22,6 +22,8 @@ class ShipmentsControllerTest < ActionDispatch::IntegrationTest
 
   test "should get index with filtered params" do
     get shipments_url, params: { status: 'DELIVERED' }
+  test "should get show" do
+    get shipments_show_url
     assert_response :success
   end
 end

--- a/shipments_tracker/test/controllers/shipments_controller_test.rb
+++ b/shipments_tracker/test/controllers/shipments_controller_test.rb
@@ -14,7 +14,7 @@ class ShipmentsControllerTest < ActionDispatch::IntegrationTest
     get shipments_url
     assert_response :success
   end
-
+  
   test "should get index with filtered params" do
     get shipments_url, params: { carrier_name: 'FEDEX' }
     assert_response :success

--- a/shipments_tracker/test/controllers/shipments_controller_test.rb
+++ b/shipments_tracker/test/controllers/shipments_controller_test.rb
@@ -22,13 +22,11 @@ class ShipmentsControllerTest < ActionDispatch::IntegrationTest
 
   test "should get index with filtered params" do
     get shipments_url, params: { status: 'DELIVERED' }
-  test "should get show" do
-    get shipments_show_url
     assert_response :success
   end
 
-  test "should get index" do
-    get shipments_index_url
+  test "should get show" do
+    get shipments_show_url
     assert_response :success
   end
 end

--- a/shipments_tracker/test/controllers/shipments_controller_test.rb
+++ b/shipments_tracker/test/controllers/shipments_controller_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
 class ShipmentsControllerTest < ActionDispatch::IntegrationTest
-
   setup do
     @shipment = shipments(:one)
   end
@@ -23,11 +22,6 @@ class ShipmentsControllerTest < ActionDispatch::IntegrationTest
 
   test "should get index with filtered params" do
     get shipments_url, params: { status: 'DELIVERED' }
-    assert_response :success
-  end
-  
-  test "should get index" do
-    get shipments_index_url
     assert_response :success
   end
 end

--- a/shipments_tracker/test/controllers/shipments_controller_test.rb
+++ b/shipments_tracker/test/controllers/shipments_controller_test.rb
@@ -14,7 +14,7 @@ class ShipmentsControllerTest < ActionDispatch::IntegrationTest
     get shipments_url
     assert_response :success
   end
-  
+
   test "should get index with filtered params" do
     get shipments_url, params: { carrier_name: 'FEDEX' }
     assert_response :success

--- a/shipments_tracker/test/controllers/shipments_controller_test.rb
+++ b/shipments_tracker/test/controllers/shipments_controller_test.rb
@@ -25,4 +25,9 @@ class ShipmentsControllerTest < ActionDispatch::IntegrationTest
     get shipments_url, params: { status: 'DELIVERED' }
     assert_response :success
   end
+  
+  test "should get index" do
+    get shipments_index_url
+    assert_response :success
+  end
 end

--- a/shipments_tracker/test/controllers/shipments_controller_test.rb
+++ b/shipments_tracker/test/controllers/shipments_controller_test.rb
@@ -26,4 +26,9 @@ class ShipmentsControllerTest < ActionDispatch::IntegrationTest
     get shipments_show_url
     assert_response :success
   end
+
+  test "should get index" do
+    get shipments_index_url
+    assert_response :success
+  end
 end


### PR DESCRIPTION
# Description

What did you implement/Why did you implement this?

- The shipments_controller controller was created to apply the shipments filtering logic.
- Made a migration to add a default value in the role field in the user model.
- A before action was added to authenticate the user if he is not.

## Evidence
you can run rails s in console inside the shipments_tracker project and navigate to: http://127.0.0.1:3000/shipments/index
<img width="1440" alt="Screenshot 2023-08-11 at 17 26 34" src="https://github.com/BrightCoders-Institute/proyecto-final-ror-team1/assets/42948949/99e46089-8632-4be3-8860-7864314f6212">
<img width="1440" alt="Screenshot 2023-08-11 at 17 47 54" src="https://github.com/BrightCoders-Institute/proyecto-final-ror-team1/assets/42948949/e138a06f-aa9d-4104-a603-ae78b1950609">



## Screenshots